### PR TITLE
Release Script

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[target.x86_64-unknown-linux-musl]
+linker = "x86_64-linux-musl-gcc"

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 Dockerfile
 nginx.conf
 *.log
+*.tar.gz
 /target

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "cc"
+version = "1.0.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bbb73db36c1246e9034e307d0fba23f9a2e251faa47ade70c1bd252220c8311"
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,6 +138,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e704a02bcaecd4a08b93a23f6be59d0bd79cd161e0963e9499165a0a35df7bd"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topngx"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Garrett Squire <github@garrettsquire.com>"]
 edition = "2018"
 description = "Top for NGINX"
@@ -18,6 +18,9 @@ regex = "1.3"
 rusqlite = "0.23"
 structopt = "0.3"
 tabwriter = "1.2"
+
+[features]
+bundled-sqlite = ["rusqlite/bundled"]
 
 [profile.release]
 lto = true

--- a/build_release
+++ b/build_release
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+set -eux
+
+# The semantic version is the first and only argument.
+VERSION="$1"
+
+cargo build --release
+
+# Cross compile for Linux via the MUSL toolchain.
+TARGET_CC=x86_64-linux-musl-gcc \
+    cargo build \
+    --release \
+    --target x86_64-unknown-linux-musl \
+    --features bundled-sqlite
+
+# Build archives.
+shasum -a 256 target/release/topngx > target/release/SHA256
+shasum -a 256 target/x86_64-unknown-linux-musl/release/topngx \
+    > target/x86_64-unknown-linux-musl/release/SHA256
+
+tar -czf "topngx-$VERSION-x86_64-apple-darwin.tar.gz" \
+    -C target/release \
+    SHA256 topngx
+
+tar -czf "topngx-$VERSION-x86_64-unknown-linux-musl.tar.gz" \
+    -C target/x86_64-unknown-linux-musl/release \
+    SHA256 topngx

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -112,7 +112,7 @@ impl Processor {
                     match val {
                         Value::Null => write!(&mut tw, "null\t")?,
                         Value::Integer(i) => write!(&mut tw, "{}\t", i)?,
-                        Value::Real(r) => write!(&mut tw, "{}\t", r)?,
+                        Value::Real(r) => write!(&mut tw, "{:.2}\t", r)?,
                         Value::Text(t) => write!(&mut tw, "{}\t", t)?,
                         Value::Blob(b) => write!(&mut tw, "{}\t", String::from_utf8(b)?)?,
                     }


### PR DESCRIPTION
- Create a release script for Mac and Linux MUSL binaries.
- Format floats to two decimal places in the output.

Closes #2